### PR TITLE
Correct Facebook picture URL

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/oauth2/facebook/FacebookAuthUser.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/facebook/FacebookAuthUser.java
@@ -127,13 +127,9 @@ public class FacebookAuthUser extends BasicOAuth2AuthUser implements
 	}
 
 	public String getPicture() {
-		if (link != null && !link.isEmpty()) {
-			// According to
-			// https://developers.facebook.com/docs/reference/api/#pictures
-			return getProfileLink() + "/picture";
-		} else {
-			return null;
-		}
+		// According to
+		// https://developers.facebook.com/docs/reference/api/#pictures
+		return String.format("https://graph.facebook.com/%s/picture", getUsername());
 	}
 
 	public Locale getLocale() {


### PR DESCRIPTION
According to the Facebook API documentation (https://developers.facebook.com/docs/reference/api/#pictures), the picture URL is not : 

```
getProfileLink() + "/picture";
```

but 

```
https://graph.facebook.com/username/picture
```
