### PR TITLE
SignupResult and LoginResult not found while generating scaladoc

### DIFF
--- a/samples/java/play-authenticate-usage/app/providers/MyUsernamePasswordAuthProvider.java
+++ b/samples/java/play-authenticate-usage/app/providers/MyUsernamePasswordAuthProvider.java
@@ -123,7 +123,7 @@ public class MyUsernamePasswordAuthProvider
 	}
 
 	@Override
-	protected SignupResult signupUser(final MyUsernamePasswordAuthUser user) {
+	protected com.feth.play.module.pa.providers.password.UsernamePasswordAuthProvider.SignupResult signupUser(final MyUsernamePasswordAuthUser user) {
 		final User u = User.findByUsernamePasswordIdentity(user);
 		if (u != null) {
 			if (u.emailValidated) {
@@ -146,7 +146,7 @@ public class MyUsernamePasswordAuthProvider
 	}
 
 	@Override
-	protected LoginResult loginUser(
+	protected com.feth.play.module.pa.providers.password.UsernamePasswordAuthProvider.LoginResult loginUser(
 			final MyLoginUsernamePasswordAuthUser authUser) {
 		final User u = User.findByUsernamePasswordIdentity(authUser);
 		if (u == null) {


### PR DESCRIPTION
There appears to be a bug during the scaladoc generation: the compiler can't find SignupResult and LoginResult so the dist command fails.
Writing the fullly qualified class names seems to fix the problem.
