### PR TITLE
Update samples/java/play-authenticate-usage/conf/play-authenticate/mine....

### DIFF
--- a/samples/java/play-authenticate-usage/conf/play-authenticate/mine.conf
+++ b/samples/java/play-authenticate-usage/conf/play-authenticate/mine.conf
@@ -25,6 +25,8 @@ play-authenticate {
                 # Mailing name
                 name=Play Authenticate
             }
+            # Pause between email jobs (in seconds)
+            delay=1
         }
         # Whether to directly log in after the password reset (true)
         # or send the user to the login page (false)


### PR DESCRIPTION
...conf

Little omission. It would go un-noticed unless you try to compile from source, play-authenticate code together with play-authenticate-usage. If you do you'd get an error. 
Not sure from where it is loaded if using the play-authenticated as a module, and why it does not give any errors in that case.
