### PR TITLE
Facebook: Add username to default attribute set.

### DIFF
--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -137,7 +137,7 @@ play-authenticate {
         # Comma-separated list of fields to retrieve from this Facebook user.
         # See possible values here: https://developers.facebook.com/docs/reference/api/user/
         # Note that some fields may require additional permissions on your Facebook App.
-        userInfoFields="id,name,first_name,middle_name,last_name,link,gender,email,timezone,locale,updated_time"
+        userInfoFields="id,name,first_name,middle_name,last_name,username,link,gender,email,timezone,locale,updated_time"
 
         scope=email
         


### PR DESCRIPTION
This was missing when introducing customizable Facebook
fields to retrieve from Facebook.
