### PR TITLE
Update UsernamePasswordAuthProvider.java

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
@@ -115,7 +115,8 @@ public abstract class UsernamePasswordAuthProvider<R, UL extends UsernamePasswor
 				return authUser;
 			case WRONG_PASSWORD:
 				// don't expose this - it might harm users privacy if anyone
-				// knows they signed up for our service
+				// knows they signed up for our service				
+				return onLoginUserNotFound(context);
 			case NOT_FOUND:
 				// forward to login page
 				return onLoginUserNotFound(context);


### PR DESCRIPTION
In order to avoid exposing the fact that the user has/has not an account, WRONG_PASSWORD and NOT_FOUND should give the same result. It can be argued that if the one that is checking does not have an account he won't know anyway what the difference would be, but then the attacker might just as well have an account.
