### PR TITLE
Fixing test-app for 2.2

### DIFF
--- a/test-app/project/Build.scala
+++ b/test-app/project/Build.scala
@@ -8,14 +8,14 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0-SNAPSHOT"
 
     val appDependencies = Seq(
-      javaCore, cache
+      javaCore
     )
-    
+
     val playAuthenticate = play.Project(
       "play-authenticate", "1.0-SNAPSHOT", Seq(javaCore, cache), path = file("modules/play-authenticate")
     ).settings(
       libraryDependencies += "org.apache.httpcomponents" % "httpclient" % "4.2",
-      libraryDependencies += "com.feth" %% "play-easymail" % "0.3-SNAPSHOT",
+      libraryDependencies += "com.feth" %% "play-easymail" % "0.5-SNAPSHOT",
       libraryDependencies += "org.mindrot" % "jbcrypt" % "0.3m",
       libraryDependencies += "commons-lang" % "commons-lang" % "2.6",
 

--- a/test-app/test/ScalaControllerSpec.scala
+++ b/test-app/test/ScalaControllerSpec.scala
@@ -18,73 +18,74 @@ import providers.TestUsernamePasswordAuthProvider
  * You can mock out a whole application including requests, plugins etc.
  * For more information, consult the wiki.
  */
-class ScalaControllerSpec extends PlaySpecification {
+object ScalaControllerSpec extends PlaySpecification {
 
   "ScalaController" should {
 
     "send 303 for index page without login" in new WithApplication {
-      val result = controllers.ScalaController.index()(FakeRequest())
+      val result = controllers.ScalaController.index()(FakeRequest()).run
       status(result) must equalTo(SEE_OTHER);
-      redirectLocation(result) must beSome like { case Some(s: String) =>
-        s must_== controllers.routes.Application.login.url
+      redirectLocation(result) must beSome like {
+        case Some(s: String) =>
+          s must_== controllers.routes.Application.login.url
       }
     }
 
     "send 200 for index page with login" in new WithApplication {
       val someSession = signupAndLogin()
       val result = controllers.ScalaController.index()(
-            FakeRequest().withSession(someSession.get.data.toSeq: _*))
+        FakeRequest().withSession(someSession.get.data.toSeq: _*)).run
       status(result) must equalTo(OK)
     }
+  }
 
-    def signupAndLogin(): Option[Session] = {
-      val email = "user@example.com"
-      val password = "PaSSW0rd"
-      def fakeRequestCall(call: Call): FakeRequest[AnyContentAsEmpty.type] = {
-        FakeRequest(call.method, call.url)
+  def signupAndLogin(): Option[Session] = {
+    val email = "user@example.com"
+    val password = "PaSSW0rd"
+    def fakeRequestCall(call: Call): FakeRequest[AnyContentAsEmpty.type] = {
+      FakeRequest(call.method, call.url)
+    }
+    def signup(email: String, password: String) = {
+      val someResult = route(fakeRequestCall(
+        controllers.routes.Application.doSignup())
+        .withFormUrlEncodedBody("email" -> email, "password" -> password))
+      someResult foreach { status(_) must_== SEE_OTHER }
+      upAuthProvider.getVerificationToken(email)
+    }
+    def validate(token: String) {
+      // Validate the token
+      token must not beNull;
+      Logger.debug(s"Verifying token: $token")
+      val someResult = route(fakeRequestCall(
+        controllers.routes.Application.verify(token)))
+      someResult foreach { result =>
+        status(result) must_== SEE_OTHER
+        upAuthProvider.getVerificationToken(email) must beNull
+        // We should actually be logged in here, but let's ignore that
+        // as we want to test login too.
+        redirectLocation(result) must beSome("/")
       }
-      def signup(email: String, password: String) = {
-        val someResult = route(fakeRequestCall(
-          controllers.routes.Application.doSignup())
-          .withFormUrlEncodedBody("email" -> email, "password" -> password))
-        someResult foreach { status(_) must_== SEE_OTHER }
-        upAuthProvider.getVerificationToken(email)
-      }
-      def validate(token: String) {
-        // Validate the token
-        token must not beNull;
-        Logger.debug(s"Verifying token: $token")
-        val someResult = route(fakeRequestCall(
-          controllers.routes.Application.verify(token)))
-        someResult foreach { result =>
-          status(result) must_== SEE_OTHER
-          upAuthProvider.getVerificationToken(email) must beNull
-          // We should actually be logged in here, but let's ignore that
-          // as we want to test login too.
-          redirectLocation(result) must beSome("/")
-        }
-      }
-      def login(username: String, password: String) = {
-        // Log the user in
-        val someResult = route(fakeRequestCall(
-          controllers.routes.Application.doLogin())
-          .withFormUrlEncodedBody("email" -> email, "password" -> password))
-        someResult map { result =>
-          status(result) must_== SEE_OTHER
-          redirectLocation(result) must beSome like { case Some(s: String) =>
+    }
+    def login(username: String, password: String) = {
+      // Log the user in
+      val someResult = route(fakeRequestCall(
+        controllers.routes.Application.doLogin())
+        .withFormUrlEncodedBody("email" -> email, "password" -> password))
+      someResult map { result =>
+        status(result) must_== SEE_OTHER
+        redirectLocation(result) must beSome like {
+          case Some(s: String) =>
             s must_== "/"
-          }
-          session(result)
         }
+        session(result)
       }
-      val token = signup(email, password)
-      validate(token)
-      login(email, password)
     }
+    val token = signup(email, password)
+    validate(token)
+    login(email, password)
+  }
 
-    def upAuthProvider: TestUsernamePasswordAuthProvider = {
-      Play.current.plugin(classOf[TestUsernamePasswordAuthProvider]).get
-    }
-
+  def upAuthProvider: TestUsernamePasswordAuthProvider = {
+    Play.current.plugin(classOf[TestUsernamePasswordAuthProvider]).get
   }
 }


### PR DESCRIPTION
The [new results structure in Play 2.2](http://www.playframework.com/documentation/2.2.x/Migration22) broke some parts of test-app introduced in #82. An upgrade to play-easymail 0.5-SNAPSHOT was also required.
