### PR TITLE
Dependencies in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can find a live demo on [heroku](https://play-authenticate.herokuapp.com/ "P
 ## Quickstart
 Clone the project, go to `samples/java/play-authenticate-usage` and run `sbt run` to see a sample application. There are only very few of the providers enabled, because for most of them, you need to add OAuth credentials which you can get at the various different providers.
 
-### Include the Dependencies
+### Including the Dependencies
 
 Play-Authenticate is available in [Maven Central](http://search.maven.org/#artifactdetails%7Ccom.feth%7Cplay-authenticate_2.11%7C0.6.8%7Cjar).
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,25 @@ You can find a live demo on [heroku](https://play-authenticate.herokuapp.com/ "P
 ## Quickstart
 Clone the project, go to `samples/java/play-authenticate-usage` and run `sbt run` to see a sample application. There are only very few of the providers enabled, because for most of them, you need to add OAuth credentials which you can get at the various different providers.
 
+### Include the Dependencies
+
+Play-Authenticate is available in [Maven Central](http://search.maven.org/#artifactdetails%7Ccom.feth%7Cplay-authenticate_2.11%7C0.6.8%7Cjar).
+
+```
+<dependency>
+    <groupId>com.feth</groupId>
+    <artifactId>play-authenticate_2.11</artifactId>
+    <version>0.6.8</version>
+</dependency>
+```
+or
+
+```
+val appDependencies = Seq(
+  "com.feth" %% "play-authenticate" % "0.6.8"
+  )
+```
+
 ## Features
 
 * Fully customizable and localizable controllers and views (e.g. Play Authenticate allows you to define your own controllers and views for every visual step of the signup and/or log in process)


### PR DESCRIPTION
See #242 .

A trivial update to include deps in Readme. Mainly this is just a UX thing for the user who has an app, ready to go and comes to the project page. If I want to include and start playing around, I can straight away instead of going to find examples.

Up to you whether its worth including, just a thought.