### PR TITLE
Implements refresh token behaviour

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/oauth2/OAuth2AuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/OAuth2AuthProvider.java
@@ -198,9 +198,10 @@ public abstract class OAuth2AuthProvider<U extends AuthUserIdentity, I extends O
 			final I info = getAccessToken(code, request);
             // Store refresh token to cache
             String token = info.getRefreshToken();
-            Logger.debug("1-add to cache refreshToken=" + token);
             if(!Strings.isNullOrEmpty(token)) {
-                Logger.debug("add to cache refreshToken=" + token);
+		        if (Logger.isDebugEnabled()) {
+                    Logger.debug("add to cache refreshToken=" + token);
+		        }
                 PlayAuthenticate.storeInCache(context.session(), OAuth2AuthProvider.Constants.REFRESH_TOKEN, token);
             }
             return transform(info, callbackState);

--- a/code/app/com/feth/play/module/pa/providers/oauth2/google/GoogleAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/google/GoogleAuthProvider.java
@@ -1,14 +1,30 @@
 package com.feth.play.module.pa.providers.oauth2.google;
 
+import com.feth.play.module.pa.PlayAuthenticate;
+import com.feth.play.module.pa.user.AuthUser;
+import com.feth.play.module.pa.user.SessionAuthUser;
+import com.google.common.base.Strings;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.entity.ContentType;
+import org.apache.http.message.BasicNameValuePair;
 import play.Application;
+import play.Configuration;
 import play.Logger;
 import play.libs.ws.WS;
+import play.libs.ws.WSRequestHolder;
 import play.libs.ws.WSResponse;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.feth.play.module.pa.exceptions.AccessTokenException;
 import com.feth.play.module.pa.exceptions.AuthException;
 import com.feth.play.module.pa.providers.oauth2.OAuth2AuthProvider;
+import play.mvc.Http;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 public class GoogleAuthProvider extends
 		OAuth2AuthProvider<GoogleAuthUser, GoogleAuthInfo> {
@@ -62,4 +78,43 @@ public class GoogleAuthProvider extends
 		}
 	}
 
+    @Override
+    public AuthUser refresh(AuthUser authUser, Http.Session session) {
+        Configuration config = PlayAuthenticate.getConfiguration().getConfig(PROVIDER_KEY);
+        String url = config.getString(SettingKeys.REFRESH_TOKEN_URL);
+        String refreshToken = PlayAuthenticate.getFromCache(session, OAuth2AuthProvider.Constants.REFRESH_TOKEN);
+        if (Strings.isNullOrEmpty(refreshToken)){
+            Logger.error("refresh token not found from cache");
+            return null;
+        }
+        if(Strings.isNullOrEmpty(url)) {
+            return null;
+        }
+        final List<NameValuePair> params = new ArrayList<NameValuePair>();
+        params.add(new BasicNameValuePair(OAuth2AuthProvider.Constants.REFRESH_TOKEN, refreshToken));
+        params.add(new BasicNameValuePair(OAuth2AuthProvider.Constants.CLIENT_ID, config.getString(OAuth2AuthProvider.SettingKeys.CLIENT_ID)));
+        params.add(new BasicNameValuePair(OAuth2AuthProvider.Constants.CLIENT_SECRET, config.getString(OAuth2AuthProvider.SettingKeys.CLIENT_SECRET)));
+        params.add(new BasicNameValuePair(OAuth2AuthProvider.Constants.GRANT_TYPE, "refresh_token"));
+
+        final WSRequestHolder request = WS
+                .url(url);
+        request.setContentType(ContentType.APPLICATION_FORM_URLENCODED.toString());
+        WSResponse response = request.post(URLEncodedUtils.format(params, Charset.forName("UTF-8"))).get(getTimeout());
+        AuthUser refreshedUser = null;
+        if (response == null ) {
+            Logger.error("[" + authUser.getId() + "] refresh token | fail | No response received for " + url);
+        } else if(response.getStatus() != 200) {
+            Logger.error("[" + authUser.getId() + "] refresh token | fail | HTTP_STATUS="+response.getStatus()+response.getBody());
+        } else {
+            JsonNode payload = response.asJson();
+            JsonNode expiresNode = payload.get(OAuth2AuthProvider.Constants.EXPIRES_IN);
+            if(expiresNode != null) {
+                long expiresDate = new Date().getTime() + expiresNode.asLong() * 1000;
+                refreshedUser = new SessionAuthUser(authUser.getProvider(), authUser.getId(), expiresDate);
+                //update value in session
+                PlayAuthenticate.storeUser(session, refreshedUser);
+            }
+        }
+        return refreshedUser;
+    }
 }

--- a/code/conf/reference.conf
+++ b/code/conf/reference.conf
@@ -177,11 +177,12 @@ play-authenticate {
         }
         authorizationUrl="https://accounts.google.com/o/oauth2/auth"
         accessTokenUrl="https://accounts.google.com/o/oauth2/token"
+        refreshTokenUrl="https://www.googleapis.com/oauth2/v3/token"
         userInfoUrl="https://www.googleapis.com/oauth2/v1/userinfo"
         scope="https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
 
         # Additional parameters - Read more about them here: https://developers.google.com/accounts/docs/OAuth2WebServer#offline
-        # accessType="offline"
+        accessType="offline"
         # approvalPrompt="force"
 
         # Get the credentials here: https://code.google.com/apis/console

--- a/code/version.sbt
+++ b/code/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.9-SNAPSHOT"
+version in ThisBuild := "0.6.10-SNAPSHOT"


### PR DESCRIPTION
This improvements relates to this issue #57 

I create a method refresh which contains the logic to perform a refresh token action. I implement only for GoogleAuthProvider. I modify PlayAuthenticate.isLoggedIn method to launch the refresh token action when the current token is expired.

