### PR TITLE
Make all PROVIDER_KEY public (some are already)

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/oauth1/linkedin/LinkedinAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth1/linkedin/LinkedinAuthProvider.java
@@ -16,7 +16,7 @@ import com.feth.play.module.pa.providers.oauth1.OAuth1AuthProvider;
 public class LinkedinAuthProvider extends
 		OAuth1AuthProvider<LinkedinAuthUser, LinkedinAuthInfo> {
 
-	static final String PROVIDER_KEY = "linkedin";
+	public static final String PROVIDER_KEY = "linkedin";
 
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
 	private static final String USER_EMAIL_URL_SETTING_KEY = "userEmailUrl";

--- a/code/app/com/feth/play/module/pa/providers/oauth1/twitter/TwitterAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth1/twitter/TwitterAuthProvider.java
@@ -16,7 +16,7 @@ import com.feth.play.module.pa.providers.oauth1.OAuth1AuthProvider;
 public class TwitterAuthProvider extends
 		OAuth1AuthProvider<TwitterAuthUser, TwitterAuthInfo> {
 
-	static final String PROVIDER_KEY = "twitter";
+	public static final String PROVIDER_KEY = "twitter";
 
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
     private static final String DENIED_KEY = "denied";

--- a/code/app/com/feth/play/module/pa/providers/oauth1/xing/XingAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth1/xing/XingAuthProvider.java
@@ -20,7 +20,7 @@ import com.feth.play.module.pa.providers.oauth1.OAuth1AuthProvider;
 public class XingAuthProvider extends
 		OAuth1AuthProvider<XingAuthUser, XingAuthInfo> {
 
-	static final String PROVIDER_KEY = "xing";
+	public static final String PROVIDER_KEY = "xing";
 
 	private static final String NODE_USERS = "users";
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";

--- a/code/app/com/feth/play/module/pa/providers/oauth2/foursquare/FoursquareAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/foursquare/FoursquareAuthProvider.java
@@ -14,7 +14,7 @@ import com.feth.play.module.pa.user.AuthUserIdentity;
 public class FoursquareAuthProvider extends
 		OAuth2AuthProvider<FoursquareAuthUser, FoursquareAuthInfo> {
 
-	static final String PROVIDER_KEY = "foursquare";
+	public static final String PROVIDER_KEY = "foursquare";
 
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
 	private static final String OAUTH_TOKEN = "oauth_token";

--- a/code/app/com/feth/play/module/pa/providers/oauth2/github/GithubAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/github/GithubAuthProvider.java
@@ -15,7 +15,7 @@ import com.feth.play.module.pa.providers.oauth2.OAuth2AuthProvider;
 public class GithubAuthProvider extends
         OAuth2AuthProvider<GithubAuthUser, GithubAuthInfo> {
 
-    static final String PROVIDER_KEY = "github";
+    public static final String PROVIDER_KEY = "github";
 
     private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
 

--- a/code/app/com/feth/play/module/pa/providers/oauth2/pocket/PocketAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/pocket/PocketAuthProvider.java
@@ -28,7 +28,7 @@ import com.feth.play.module.pa.user.AuthUserIdentity;
 public class PocketAuthProvider extends
 		OAuth2AuthProvider<PocketAuthUser, PocketAuthInfo> {
 
-	static final String PROVIDER_KEY = "pocket";
+	public static final String PROVIDER_KEY = "pocket";
 
 	public PocketAuthProvider(Application app) {
 		super(app);

--- a/code/app/com/feth/play/module/pa/providers/oauth2/untappd/UntappdAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/untappd/UntappdAuthProvider.java
@@ -25,7 +25,7 @@ import com.feth.play.module.pa.providers.oauth2.OAuth2AuthProvider;
 public class UntappdAuthProvider extends
 		OAuth2AuthProvider<UntappdAuthUser, UntappdAuthInfo> {
 
-	static final String PROVIDER_KEY = "untappd";
+	public static final String PROVIDER_KEY = "untappd";
 
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
 

--- a/code/app/com/feth/play/module/pa/providers/oauth2/vk/VkAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth2/vk/VkAuthProvider.java
@@ -15,7 +15,7 @@ import com.feth.play.module.pa.providers.oauth2.OAuth2AuthProvider;
  */
 public class VkAuthProvider extends OAuth2AuthProvider<VkAuthUser, VkAuthInfo> {
 
-	static final String PROVIDER_KEY = "vk";
+	public static final String PROVIDER_KEY = "vk";
 
 	private static final String USER_INFO_URL_SETTING_KEY = "userInfoUrl";
 	private static final String USER_INFO_FIELDS_SETTING_KEY = "userInfoFields";

--- a/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
@@ -23,7 +23,7 @@ import com.feth.play.module.pa.user.NameIdentity;
 public abstract class UsernamePasswordAuthProvider<R, UL extends UsernamePasswordAuthUser, US extends UsernamePasswordAuthUser, L extends UsernamePasswordAuthProvider.UsernamePassword, S extends UsernamePasswordAuthProvider.UsernamePassword>
 		extends AuthProvider {
 
-	protected static final String PROVIDER_KEY = "password";
+	public static final String PROVIDER_KEY = "password";
 
 	protected static final String SETTING_KEY_MAIL = "mail";
 

--- a/code/app/com/feth/play/module/pa/providers/wwwauth/negotiate/SpnegoAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/wwwauth/negotiate/SpnegoAuthProvider.java
@@ -52,7 +52,7 @@ public class SpnegoAuthProvider extends WWWAuthenticateProvider {
 		}
 	}
 
-	final static String PROVIDER_KEY = "spnego";
+	public final static String PROVIDER_KEY = "spnego";
 	private static Oid SPNEGO_MECH_OID;
 	static {
 		try {


### PR DESCRIPTION
This should be a trivial change.
The facebook, google or the eventbrite `PROVIDER_KEY` constants are public already.
We needed to access the keys in our code for some db lookups etc.
Thanks!