### PR TITLE
Make identity interface inner classes serializable to fix caching exception

### DIFF
--- a/code/app/com/feth/play/module/pa/user/EducationsIdentity.java
+++ b/code/app/com/feth/play/module/pa/user/EducationsIdentity.java
@@ -1,10 +1,11 @@
 package com.feth.play.module.pa.user;
 
+import java.io.Serializable;
 import java.util.Collection;
 
 public interface EducationsIdentity {
   
-  public static class EducationInfo {
+  public static class EducationInfo implements Serializable {
     protected String id;
     protected String schoolName;
     protected String degree;

--- a/code/app/com/feth/play/module/pa/user/EmploymentsIdentity.java
+++ b/code/app/com/feth/play/module/pa/user/EmploymentsIdentity.java
@@ -1,9 +1,10 @@
 package com.feth.play.module.pa.user;
 
+import java.io.Serializable;
 import java.util.Collection;
 
 public interface EmploymentsIdentity {
-  public static class EmploymentInfo {
+  public static class EmploymentInfo implements Serializable {
     protected String id;
     protected String title;
     protected String summary;


### PR DESCRIPTION
This fixes #291. In addition to making the `EmploymentsIdentity.EmploymentInfo` class implement the `Serializable` interface, the same change has been made to `EducationsIdentity.EducationInfo`, as it is vulnerable to the same problem.

Local testing shows that linking a LinkedIn account to an existing user account now completes normally.