### PR TITLE
Fixes a design issue that prevents extension from Scala applications

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/password/UsernamePasswordAuthProvider.java
@@ -154,20 +154,6 @@ public abstract class UsernamePasswordAuthProvider<R, UL extends UsernamePasswor
 				Case.SIGNUP);
 	}
 
-	private S getSignup(final Context ctx) {
-		// TODO change to getSignupForm().bindFromRequest(request) after 2.1
-		Http.Context.current.set(ctx);
-		final Form<S> filledForm = getSignupForm().bindFromRequest();
-		return filledForm.get();
-	}
-
-	private L getLogin(final Context ctx) {
-		// TODO change to getSignupForm().bindFromRequest(request) after 2.1
-		Http.Context.current.set(ctx);
-		final Form<L> filledForm = getLoginForm().bindFromRequest();
-		return filledForm.get();
-	}
-
 	/**
 	 * You might overwrite this to provide your own recipient format
 	 * implementation,
@@ -257,9 +243,9 @@ public abstract class UsernamePasswordAuthProvider<R, UL extends UsernamePasswor
 
 	protected abstract SignupResult signupUser(final US user);
 
-	protected abstract Form<S> getSignupForm();
+	protected abstract S getSignup(final Context ctx);
 
-	protected abstract Form<L> getLoginForm();
+	protected abstract L getLogin(final Context ctx);
 
 	protected abstract Call userExists(final UsernamePasswordAuthUser authUser);
 

--- a/samples/java/play-authenticate-usage/app/providers/MyUsernamePasswordAuthProvider.java
+++ b/samples/java/play-authenticate-usage/app/providers/MyUsernamePasswordAuthProvider.java
@@ -151,6 +151,22 @@ public class MyUsernamePasswordAuthProvider
 	}
 
 	@Override
+	protected MySignup getSignup(final Context ctx) {
+		// TODO change to getSignupForm().bindFromRequest(request) after 2.1
+		Context.current.set(ctx);
+		final Form<MySignup> filledForm = SIGNUP_FORM.bindFromRequest();
+		return filledForm.get();
+	}
+
+	@Override
+	protected MyLogin getLogin(final Context ctx) {
+		// TODO change to getLoginForm().bindFromRequest(request) after 2.1
+		Context.current.set(ctx);
+		final Form<MyLogin> filledForm = LOGIN_FORM.bindFromRequest();
+		return filledForm.get();
+	}
+
+	@Override
 	protected com.feth.play.module.pa.providers.password.UsernamePasswordAuthProvider.SignupResult signupUser(final MyUsernamePasswordAuthUser user) {
 		final User u = User.findByUsernamePasswordIdentity(user);
 		if (u != null) {

--- a/test-app/app/providers/TestUsernamePasswordAuthProvider.java
+++ b/test-app/app/providers/TestUsernamePasswordAuthProvider.java
@@ -179,14 +179,28 @@ public class TestUsernamePasswordAuthProvider
 		return SignupResult.USER_CREATED_UNVERIFIED;
 	}
 
-	@Override
 	protected Form<Signup> getSignupForm() {
 		return form(Signup.class);
 	}
 
-	@Override
 	protected Form<Login> getLoginForm() {
 		return form(Login.class);
+	}
+
+	@Override
+	protected Signup getSignup(final Context ctx) {
+		// TODO change to getSignupForm().bindFromRequest(request) after 2.1
+		Context.current.set(ctx);
+		final Form<Signup> filledForm = getSignupForm().bindFromRequest();
+		return filledForm.get();
+	}
+
+	@Override
+	protected Login getLogin(final Context ctx) {
+		// TODO change to getLoginForm().bindFromRequest(request) after 2.1
+		Context.current.set(ctx);
+		final Form<Login> filledForm = getLoginForm().bindFromRequest();
+		return filledForm.get();
 	}
 
 	@Override


### PR DESCRIPTION
The `com.feth.play.module.pa.providers.password.UsernamePasswordAuthProvider` abstract base implementation is used in the usage sample and requires clients to implement `play.data.Form<S> getSignupForm()` and `play.data.Form<L> getLoginForm()`. The problem is that Scala implementations will not be able to reuse the implementation because it requires Java Forms and the Form types are incompatible between Java (`play.data.Form`) and Scala (`play.api.data.Form`).

By applying this change, the partial implementation `UsernamePasswordAuthProvider` allows subclassing from Scala applications too at the very little cost of not having the Form `bindFromRequest` boilerplate code. It also allows mixed Java-Scala applications to define Forms in either way. 

The client needs to provide implementation for the `getSignup` and `getLogin` directly and as implementation can use whatever Form type it prefers.