### PR TITLE
added default constructor for SerializableRequestToken

### DIFF
--- a/code/app/com/feth/play/module/pa/providers/oauth1/OAuth1AuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth1/OAuth1AuthProvider.java
@@ -69,6 +69,9 @@ public abstract class OAuth1AuthProvider<U extends AuthUserIdentity, I extends O
 	public static class SerializableRequestToken extends RequestToken implements Serializable {
 		private static final long serialVersionUID = 1L;
 
+		public SerializableRequestToken() {
+		}
+
 		public SerializableRequestToken(RequestToken source) {
 			super(source.token, source.secret);
 		}

--- a/code/app/com/feth/play/module/pa/providers/oauth1/OAuth1AuthProvider.java
+++ b/code/app/com/feth/play/module/pa/providers/oauth1/OAuth1AuthProvider.java
@@ -70,6 +70,7 @@ public abstract class OAuth1AuthProvider<U extends AuthUserIdentity, I extends O
 		private static final long serialVersionUID = 1L;
 
 		public SerializableRequestToken() {
+			super(null, null);
 		}
 
 		public SerializableRequestToken(RequestToken source) {


### PR DESCRIPTION
To prevent java.io.NotSerializableException I have added default empty constructor. It should fix the latest issue  from the #291.